### PR TITLE
Add multi-screen wallpaper support with per-screen persist/remove controls

### DIFF
--- a/checkmark.svg
+++ b/checkmark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <polyline points="3,8 6.5,12 13,4" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/locales/de.json
+++ b/locales/de.json
@@ -27,6 +27,7 @@
     "set_wallpaper_button": "Hintergrund festlegen",
     "preview_in_window_button": "Vorschau im Fenster",
     "stop_button": "Stopp",
+    "remove_wallpaper_button": "Hintergrundbild entfernen",
     "restore_last_button": "Letztes Hintergrundbild wiederherstellen",
     "auto_restore_checkbox": "Hintergrundbild beim Start automatisch wiederherstellen",
     "stop_on_exit_checkbox": "Hintergrund beim Beenden der App stoppen",

--- a/locales/de.json
+++ b/locales/de.json
@@ -19,6 +19,7 @@
     "disable_parallax_checkbox": "Parallax-Effekt deaktivieren (--disable-parallax)",
     "no_fullscreen_pause_checkbox": "Im Vollbildmodus nicht pausieren (--no-fullscreen-pause)",
     "windowed_mode_checkbox": "Fenstermodus (Fix für KDE/GNOME)",
+    "keep_others_checkbox": "Hintergrundbilder auf anderen Bildschirmen behalten",
     "kwin_hint": "Hinweis: Wenn das Hintergrundfenster oben bleibt, müssen Sie möglicherweise eine KWin-Regel erstellen (Alt+F3 -> Weitere Aktionen -> Spezielle Einstellungen für dieses Fenster), um es 'Im Hintergrund' (Keep Below) zu halten.",
     "adv_frame": "Erweitert",
     "set_property_label": "Eigenschaften setzen (--set-property):",

--- a/locales/en.json
+++ b/locales/en.json
@@ -19,6 +19,7 @@
     "disable_parallax_checkbox": "Disable parallax effect (--disable-parallax)",
     "no_fullscreen_pause_checkbox": "Do not pause in full-screen (--no-fullscreen-pause)",
     "windowed_mode_checkbox": "Windowed Mode (Fix for KDE/GNOME)",
+    "keep_others_checkbox": "Keep wallpapers on other screens",
     "kwin_hint": "Note: If the wallpaper window stays on top, you may need to create a KWin rule (Alt+F3 -> More Actions -> Configure Special Window Settings) to force it 'Keep Below'.",
     "adv_frame": "Advanced",
     "set_property_label": "Properties (--set-property):",

--- a/locales/en.json
+++ b/locales/en.json
@@ -27,6 +27,7 @@
     "set_wallpaper_button": "Set Wallpaper",
     "preview_in_window_button": "Preview in Window",
     "stop_button": "Stop",
+    "remove_wallpaper_button": "Remove Wallpaper",
     "show_log_button": "Show Log File",
     "restore_last_button": "Restore Last Wallpaper",
     "auto_restore_checkbox": "Auto-restore wallpaper on startup",

--- a/locales/es.json
+++ b/locales/es.json
@@ -27,6 +27,7 @@
     "set_wallpaper_button": "Establecer fondo",
     "preview_in_window_button": "Vista previa en ventana",
     "stop_button": "Detener",
+    "remove_wallpaper_button": "Eliminar fondo de pantalla",
     "restore_last_button": "Restaurar último fondo de pantalla",
     "auto_restore_checkbox": "Restaurar fondo de pantalla automáticamente al iniciar",
     "stop_on_exit_checkbox": "Detener fondos de pantalla al salir de la aplicación",

--- a/locales/es.json
+++ b/locales/es.json
@@ -19,6 +19,7 @@
     "disable_parallax_checkbox": "Deshabilitar efecto de paralaje (--disable-parallax)",
     "no_fullscreen_pause_checkbox": "No pausar en pantalla completa (--no-fullscreen-pause)",
     "windowed_mode_checkbox": "Modo de ventana (Corrección para KDE/GNOME)",
+    "keep_others_checkbox": "Mantener fondos de pantalla en otras pantallas",
     "kwin_hint": "Nota: Si la ventana del fondo de pantalla se queda arriba, es posible que deba crear una regla de KWin (Alt+F3 -> Más acciones -> Configuración especial de la ventana) para forzarla a 'Mantener debajo' (Keep Below).",
     "adv_frame": "Avanzado",
     "set_property_label": "Establecer propiedades (--set-property):",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -27,6 +27,7 @@
     "set_wallpaper_button": "Définir le fond d'écran",
     "preview_in_window_button": "Aperçu en fenêtre",
     "stop_button": "Arrêter",
+    "remove_wallpaper_button": "Supprimer le fond d'écran",
     "restore_last_button": "Restaurer le dernier fond d'écran",
     "auto_restore_checkbox": "Restaurer automatiquement le fond d'écran au démarrage",
     "stop_on_exit_checkbox": "Arrêter les fonds d'écran en quittant l'application",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -19,6 +19,7 @@
     "disable_parallax_checkbox": "Désactiver l'effet de parallaxe (--disable-parallax)",
     "no_fullscreen_pause_checkbox": "Ne pas mettre en pause en plein écran (--no-fullscreen-pause)",
     "windowed_mode_checkbox": "Mode fenêtré (Correctif pour KDE/GNOME)",
+    "keep_others_checkbox": "Conserver les fonds d'écran sur les autres écrans",
     "kwin_hint": "Note : Si la fenêtre du fond d'écran reste au-dessus, vous devrez peut-être créer une règle KWin (Alt+F3 -> Plus d'actions -> Configurer les paramètres spéciaux de la fenêtre) pour la forcer à 'Rester en dessous' (Keep Below).",
     "adv_frame": "Avancé",
     "set_property_label": "Définir les propriétés (--set-property):",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -19,6 +19,7 @@
     "disable_parallax_checkbox": "Отключить эффект параллакса (--disable-parallax)",
     "no_fullscreen_pause_checkbox": "Не ставить на паузу в полноэкранном режиме (--no-fullscreen-pause)",
     "windowed_mode_checkbox": "Оконный режим (Исправление для KDE/GNOME)",
+    "keep_others_checkbox": "Сохранять обои на других экранах",
     "kwin_hint": "Примечание: Если окно обоев будет поверх других окон, вам может понадобиться создать правило KWin для этого окна (Alt+F3 -> Другие действия -> Настройка правил для конкретного окна), чтобы оно всегда было «На заднем плане» (Keep Below).",
     "adv_frame": "Дополнительно",
     "set_property_label": "Свойства (--set-property):",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -27,6 +27,7 @@
     "set_wallpaper_button": "Установить обои",
     "preview_in_window_button": "Предпросмотр в окне",
     "stop_button": "Остановить",
+    "remove_wallpaper_button": "Убрать обои",
     "restore_last_button": "Восстановить последние обои",
     "auto_restore_checkbox": "Автоматически восстанавливать обои при запуске",
     "stop_on_exit_checkbox": "Останавливать обои при выходе из приложения",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -19,6 +19,7 @@
     "disable_parallax_checkbox": "Вимкнути ефект паралакса (--disable-parallax)",
     "no_fullscreen_pause_checkbox": "Не призупиняти в повноекранному режимі (--no-fullscreen-pause)",
     "windowed_mode_checkbox": "Віконний режим (Виправлення для KDE/GNOME)",
+    "keep_others_checkbox": "Зберігати шпалери на інших екранах",
     "kwin_hint": "Примітка: Якщо вікно шпалер знаходиться поверх інших вікон, вам може знадобитися створити правило KWin для цього вікна (Alt+F3 -> Інші дії -> Налаштувати особливі параметри вікна), щоб воно завжди було «На задньому плані» (Keep Below).",
     "adv_frame": "Додатково",
     "set_property_label": "Встановити властивості (--set-property):",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -27,6 +27,7 @@
     "set_wallpaper_button": "Встановити шпалери",
     "preview_in_window_button": "Перегляд у вікні",
     "stop_button": "Зупинити",
+    "remove_wallpaper_button": "Прибрати шпалери",
     "restore_last_button": "Відновити останні шпалери",
     "auto_restore_checkbox": "Автоматично відновлювати шпалери при запуску",
     "stop_on_exit_checkbox": "Зупиняти шпалери при виході з програми",

--- a/wallpaper_gui.py
+++ b/wallpaper_gui.py
@@ -464,15 +464,15 @@ class WallpaperApp(QMainWindow):
         layout.setContentsMargins(12, 24, 0, 0)
         layout.setSpacing(0)
         push_buttons_layout = QHBoxLayout()
-        push_buttons_layout.setContentsMargins(165, 0, 0, 0)
-        push_buttons_layout.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        push_buttons_layout.setContentsMargins(0, 0, 0, 0)
+        push_buttons_layout.setSpacing(25)
+        push_buttons_layout.setAlignment(Qt.AlignmentFlag.AlignHCenter)
         header = QHBoxLayout()
         self.btn_scan = QPushButton("scan_local_wallpapers_button")
         self.btn_scan.clicked.connect(self.start_scan)
         self.btn_scan.setFixedSize(160, 200)
         self.btn_scan.setCursor(Qt.CursorShape.PointingHandCursor)
         push_buttons_layout.addWidget(self.btn_scan)
-        push_buttons_layout.addSpacing(25)
         self.btn_set_library = QPushButton("set_wallpaper_button")
         self.btn_set_library.clicked.connect(self.run_wallpaper)
         self.btn_set_library.setFixedSize(160, 200)
@@ -483,14 +483,12 @@ class WallpaperApp(QMainWindow):
         self.btn_select_folder.clicked.connect(self.manual_scan)
         self.btn_select_folder.setFixedSize(160, 200)
         self.btn_select_folder.setCursor(Qt.CursorShape.PointingHandCursor)
-        push_buttons_layout.addSpacing(25)
         push_buttons_layout.addWidget(self.btn_select_folder)
-        self.btn_stop_library = QPushButton("stop_button")
+        self.btn_stop_library = QPushButton("remove_wallpaper_button")
         self.btn_stop_library.setObjectName("DangerButton")
         self.btn_stop_library.clicked.connect(self.stop_screen_wallpaper)
         self.btn_stop_library.setFixedSize(160, 200)
         self.btn_stop_library.setCursor(Qt.CursorShape.PointingHandCursor)
-        push_buttons_layout.addSpacing(25)
         push_buttons_layout.addWidget(self.btn_stop_library)
         layout.addLayout(push_buttons_layout)
         layout.addLayout(header)
@@ -584,7 +582,7 @@ class WallpaperApp(QMainWindow):
         self.btn_set.setText(self._("set_wallpaper_button"))
         self.btn_set_library.setText(self._("set_wallpaper_button"))
         self.btn_stop.setText(self._("stop_button"))
-        self.btn_stop_library.setText(self._("stop_button"))
+        self.btn_stop_library.setText(self._("remove_wallpaper_button"))
         self.btn_show_log.setText(self._("show_log_button"))
         self.btn_scan.setText(self._("scan_local_wallpapers_button"))
         self.btn_select_folder.setText(self._("select_folder_button"))
@@ -1199,30 +1197,23 @@ class WallpaperApp(QMainWindow):
             self.status_bar.showMessage(self._("status_all_stopped"))
 
     def stop_screen_wallpaper(self):
-        """Stop the wallpaper only for the currently selected screen.
-        When keep_others is unchecked, falls back to stopping all."""
+        """Stop the wallpaper only for the currently selected screen, leaving others untouched."""
         screen_name = self.screen_combo.currentText()
-        if self.chk_keep_others.isChecked():
-            stopped = False
-            mgr = self.screen_proc_managers.pop(screen_name, None)
-            if mgr and mgr.is_running():
-                try:
-                    mgr.stop(timeout=1)
-                    stopped = True
-                except Exception as e:
-                    logging.error("Couldn't stop wallpaper on %s: %s", screen_name, e)
-            self.screen_assignments.pop(screen_name, None)
-            # Also stop the legacy single manager in case it was running for this screen.
-            if self.wallpaper_proc_manager.is_running():
-                try:
-                    self.wallpaper_proc_manager.stop(timeout=1)
-                    stopped = True
-                except Exception as e:
-                    logging.error("Couldn't stop legacy wallpaper: %s", e)
-            self.status_bar.showMessage(self._("status_all_stopped"))
-            self.save_config()
-        else:
-            self.stop_wallpapers()
+        mgr = self.screen_proc_managers.pop(screen_name, None)
+        if mgr and mgr.is_running():
+            try:
+                mgr.stop(timeout=1)
+            except Exception as e:
+                logging.error("Couldn't stop wallpaper on %s: %s", screen_name, e)
+        self.screen_assignments.pop(screen_name, None)
+        # Also stop the legacy single manager in case it was the one running for this screen.
+        if self.wallpaper_proc_manager.is_running():
+            try:
+                self.wallpaper_proc_manager.stop(timeout=1)
+            except Exception as e:
+                logging.error("Couldn't stop legacy wallpaper: %s", e)
+        self.status_bar.showMessage(self._("status_all_stopped"))
+        self.save_config()
 
     def check_wallpaper_process(self):
         result = self.wallpaper_proc_manager.check()

--- a/wallpaper_gui.py
+++ b/wallpaper_gui.py
@@ -48,7 +48,7 @@ QPushButton#DangerButton { background-color: #FF453A; }
 QPushButton#DangerButton:hover { background-color: #D0342C; }
 QCheckBox { spacing: 8px; color: #FFFFFF; }
 QCheckBox::indicator { width: 16px; height: 16px; border-radius: 4px; border: 1px solid #666666; background: #2D2D2D; }
-QCheckBox::indicator:checked { background: #0A84FF; border-color: #0A84FF; }
+QCheckBox::indicator:checked { background: #0A84FF; border-color: #0A84FF; image: url(CHECKMARK_PATH); }
 QSlider::groove:horizontal { border: 1px solid #3A3A3A; height: 5px; background: #3f7fcf; margin: 2px 0; border-radius: 2px; }
 QSlider::handle:horizontal { background: #FFFFFF; border: 1px solid #5c5c5c; width: 18px; height: 18px; margin: -8px 0; border-radius: 9px; }
 QListWidget#WallpaperGrid { background-color: transparent; border: none; outline: none; padding: 0px 0px 0px 0px; }
@@ -256,6 +256,9 @@ class WallpaperApp(QMainWindow):
         QTimer.singleShot(500, self.restore_last_wallpaper)
 
         self.wallpaper_proc_manager = WallpaperProcessManager()
+        # Per-screen process managers and wallpaper assignments (for multi-screen support)
+        self.screen_proc_managers = {}   # screen_name -> WallpaperProcessManager
+        self.screen_assignments = {}     # screen_name -> background_id
         self.wallpaper_watchdog = QTimer()
         self.wallpaper_watchdog.setInterval(1000)
         self.wallpaper_watchdog.timeout.connect(self.check_wallpaper_process)
@@ -324,6 +327,9 @@ class WallpaperApp(QMainWindow):
         self.screen_combo.setEditable(True)
         self.add_form_row(card_main, "wallpaper_id_path_label", self.wp_id_input)
         self.add_form_row(card_main, "screen_label", self.screen_combo)
+        self.chk_keep_others = QCheckBox("keep_others_checkbox")
+        self.chk_keep_others.setChecked(True)
+        card_main.layout().addWidget(self.chk_keep_others)
         h_layout = QHBoxLayout()
         h_layout.setSpacing(20)
         layout.addLayout(h_layout)
@@ -479,6 +485,13 @@ class WallpaperApp(QMainWindow):
         self.btn_select_folder.setCursor(Qt.CursorShape.PointingHandCursor)
         push_buttons_layout.addSpacing(25)
         push_buttons_layout.addWidget(self.btn_select_folder)
+        self.btn_stop_library = QPushButton("stop_button")
+        self.btn_stop_library.setObjectName("DangerButton")
+        self.btn_stop_library.clicked.connect(self.stop_screen_wallpaper)
+        self.btn_stop_library.setFixedSize(160, 200)
+        self.btn_stop_library.setCursor(Qt.CursorShape.PointingHandCursor)
+        push_buttons_layout.addSpacing(25)
+        push_buttons_layout.addWidget(self.btn_stop_library)
         layout.addLayout(push_buttons_layout)
         layout.addLayout(header)
         
@@ -550,7 +563,9 @@ class WallpaperApp(QMainWindow):
         card.layout().addLayout(h)
 
     def apply_theme(self):
-        self.setStyleSheet(MACOS_DARK)
+        import pathlib
+        checkmark = pathlib.Path(__file__).parent / "checkmark.svg"
+        self.setStyleSheet(MACOS_DARK.replace("CHECKMARK_PATH", str(checkmark)))
 
     def update_texts(self):
         items = ["control_tab", "local_library_tab"]
@@ -569,6 +584,7 @@ class WallpaperApp(QMainWindow):
         self.btn_set.setText(self._("set_wallpaper_button"))
         self.btn_set_library.setText(self._("set_wallpaper_button"))
         self.btn_stop.setText(self._("stop_button"))
+        self.btn_stop_library.setText(self._("stop_button"))
         self.btn_show_log.setText(self._("show_log_button"))
         self.btn_scan.setText(self._("scan_local_wallpapers_button"))
         self.btn_select_folder.setText(self._("select_folder_button"))
@@ -579,6 +595,7 @@ class WallpaperApp(QMainWindow):
         self.chk_parallax.setText(self._("disable_parallax_checkbox"))
         self.chk_fs_pause.setText(self._("no_fullscreen_pause_checkbox"))
         self.chk_windowed_mode.setText(self._("windowed_mode_checkbox"))
+        self.chk_keep_others.setText(self._("keep_others_checkbox"))
         self.lbl_kwin_hint.setText(self._("kwin_hint"))
         self.btn_load_props.setText(self._("load_properties_button"))
         self.btn_apply_prop.setText(self._("apply_property_button"))
@@ -1113,14 +1130,36 @@ class WallpaperApp(QMainWindow):
         custom_args = self.input_custom_args.text()
         if custom_args:
              for arg in custom_args.split(): cmd.append(arg)
-        self.stop_wallpapers()
-        try:
-            self.wallpaper_proc_manager.start(cmd)
-            self.status_bar.showMessage(self._("status_command_launched"))
-            self.save_config()
-        except Exception as e:
-            logging.error("Couldn't run with error %s", e)
-            self.status_bar.showMessage(f"Error: {e}")
+
+        if self.chk_keep_others.isChecked():
+            # Stop only the process running on the selected screen, leave others alone.
+            old_mgr = self.screen_proc_managers.get(screen_name)
+            if old_mgr and old_mgr.is_running():
+                try:
+                    old_mgr.stop(timeout=1)
+                except Exception as e:
+                    logging.error("Couldn't stop per-screen process for %s: %s", screen_name, e)
+            try:
+                mgr = WallpaperProcessManager()
+                mgr.start(cmd)
+                self.screen_proc_managers[screen_name] = mgr
+                self.screen_assignments[screen_name] = self.wp_id_input.text()
+                self.status_bar.showMessage(self._("status_command_launched"))
+                self.save_config()
+            except Exception as e:
+                logging.error("Couldn't run with error %s", e)
+                self.status_bar.showMessage(f"Error: {e}")
+        else:
+            # Legacy path: kill everything, then start fresh on the selected screen.
+            self.stop_wallpapers()
+            self.screen_assignments = {screen_name: self.wp_id_input.text()}
+            try:
+                self.wallpaper_proc_manager.start(cmd)
+                self.status_bar.showMessage(self._("status_command_launched"))
+                self.save_config()
+            except Exception as e:
+                logging.error("Couldn't run with error %s", e)
+                self.status_bar.showMessage(f"Error: {e}")
 
     def show_log_file(self):
         log_path = self.wallpaper_proc_manager.log_path()
@@ -1131,9 +1170,22 @@ class WallpaperApp(QMainWindow):
 
     def stop_wallpapers(self):
         stopped_internal = False
+
+        # Stop all per-screen managers (multi-screen mode).
+        for screen_name, mgr in list(self.screen_proc_managers.items()):
+            if mgr.is_running():
+                try:
+                    mgr.stop(timeout=1)
+                    stopped_internal = True
+                except Exception as e:
+                    logging.error("Couldn't stop per-screen process for %s: %s", screen_name, e)
+        self.screen_proc_managers.clear()
+        self.screen_assignments.clear()
+
+        # Also stop the legacy single process manager.
         if self.wallpaper_proc_manager.is_running():
             try:
-                stopped_internal = self.wallpaper_proc_manager.stop(timeout=1)
+                stopped_internal = self.wallpaper_proc_manager.stop(timeout=1) or stopped_internal
             except Exception as e:
                 logging.error("Couldn't stop internal wallpaper process: %s", e)
 
@@ -1146,26 +1198,70 @@ class WallpaperApp(QMainWindow):
         else:
             self.status_bar.showMessage(self._("status_all_stopped"))
 
+    def stop_screen_wallpaper(self):
+        """Stop the wallpaper only for the currently selected screen.
+        When keep_others is unchecked, falls back to stopping all."""
+        screen_name = self.screen_combo.currentText()
+        if self.chk_keep_others.isChecked():
+            stopped = False
+            mgr = self.screen_proc_managers.pop(screen_name, None)
+            if mgr and mgr.is_running():
+                try:
+                    mgr.stop(timeout=1)
+                    stopped = True
+                except Exception as e:
+                    logging.error("Couldn't stop wallpaper on %s: %s", screen_name, e)
+            self.screen_assignments.pop(screen_name, None)
+            # Also stop the legacy single manager in case it was running for this screen.
+            if self.wallpaper_proc_manager.is_running():
+                try:
+                    self.wallpaper_proc_manager.stop(timeout=1)
+                    stopped = True
+                except Exception as e:
+                    logging.error("Couldn't stop legacy wallpaper: %s", e)
+            self.status_bar.showMessage(self._("status_all_stopped"))
+            self.save_config()
+        else:
+            self.stop_wallpapers()
+
     def check_wallpaper_process(self):
         result = self.wallpaper_proc_manager.check()
-        if result is None:
-            return
-        if result["expected"]:
-            return
-        returncode = result["returncode"]
-        if returncode == 0:
-            msg = "Wallpaper process exited."
-        else:
-            msg = f"Wallpaper process crashed (code {returncode})."
-        if result["log_path"]:
-            msg = f"{msg} Log: {result['log_path']}"
-        self.status_bar.showMessage(msg)
-        if hasattr(self, "tray") and self.tray.isVisible():
-            self.tray.showMessage("Wallpaper Engine", msg)
+        if result is not None and not result["expected"]:
+            returncode = result["returncode"]
+            msg = "Wallpaper process exited." if returncode == 0 else f"Wallpaper process crashed (code {returncode})."
+            if result["log_path"]:
+                msg = f"{msg} Log: {result['log_path']}"
+            self.status_bar.showMessage(msg)
+            if hasattr(self, "tray") and self.tray.isVisible():
+                self.tray.showMessage("Wallpaper Engine", msg)
+
+        # Check per-screen managers.
+        for screen_name in list(self.screen_proc_managers.keys()):
+            mgr = self.screen_proc_managers.get(screen_name)
+            if mgr is None:
+                continue
+            result = mgr.check()
+            if result is None:
+                continue
+            if result["expected"]:
+                self.screen_proc_managers.pop(screen_name, None)
+                self.screen_assignments.pop(screen_name, None)
+                continue
+            returncode = result["returncode"]
+            msg = f"Wallpaper on {screen_name} exited." if returncode == 0 else f"Wallpaper on {screen_name} crashed (code {returncode})."
+            if result["log_path"]:
+                msg = f"{msg} Log: {result['log_path']}"
+            self.status_bar.showMessage(msg)
+            if hasattr(self, "tray") and self.tray.isVisible():
+                self.tray.showMessage("Wallpaper Engine", msg)
+            self.screen_proc_managers.pop(screen_name, None)
+            self.screen_assignments.pop(screen_name, None)
 
     def restore_last_wallpaper(self):
         c = self.config.get("last_wallpaper", {})
         if not c: return
+        keep_others = c.get("keep_others", True)
+        self.chk_keep_others.setChecked(keep_others)
         self.wp_id_input.setText(c.get("background_id", ""))
         self.screen_combo.setCurrentText(c.get("screen", ""))
         self.chk_silent.setChecked(c.get("silent", False))
@@ -1178,12 +1274,65 @@ class WallpaperApp(QMainWindow):
         self.chk_fs_pause.setChecked(c.get("no-fullscreen-pause", False))
         self.input_custom_args.setText(c.get("custom_args", ""))
         self.chk_windowed_mode.setChecked(c.get("windowed_mode", False))
+        # Kill any orphaned processes from a previous crash before starting new ones.
+        self.kill_external_wallpapers()
         self.run_wallpaper()
+        # Restore wallpapers on other screens saved from the previous session.
+        if keep_others:
+            saved_assignments = self.config.get("screen_assignments", {})
+            primary_screen = c.get("screen", "")
+            for screen_name, bg_id in saved_assignments.items():
+                if screen_name == primary_screen:
+                    continue
+                if not bg_id:
+                    continue
+                self._launch_screen(screen_name, bg_id)
         # Library Settings
         self.sorting_type.setCurrentText(self.config.get("sorting_type", "name"))
         self.sort_reversed_state = self.config.get("reversed", False)
         self.btn_reverse_sorted.setText("↑") if self.sort_reversed_state == False else self.btn_reverse_sorted.setText("↓")
         self.watcher.library_changed.emit()
+
+    def _launch_screen(self, screen_name, bg_id):
+        """Start linux-wallpaperengine on a specific screen with the given wallpaper ID,
+        using current audio/perf settings. Does not affect other running screens."""
+        if not bg_id:
+            return
+        old_mgr = self.screen_proc_managers.get(screen_name)
+        if old_mgr and old_mgr.is_running():
+            try:
+                old_mgr.stop(timeout=1)
+            except Exception as e:
+                logging.error("Couldn't stop per-screen process for %s: %s", screen_name, e)
+        cmd = ['linux-wallpaperengine']
+        if self.chk_windowed_mode.isChecked():
+            geom = "0x0x1920x1080"
+            found = next((s for s in self.screens if s["name"] == screen_name), None)
+            if found:
+                geom = f"{found['x']}x{found['y']}x{found['w']}x{found['h']}"
+            cmd.extend(['--window', geom])
+        else:
+            cmd.extend(['--screen-root', screen_name])
+        cmd.extend(['--bg', bg_id])
+        if self.chk_silent.isChecked(): cmd.append('--silent')
+        elif self.slider_volume.value() != 15: cmd.extend(['--volume', str(self.slider_volume.value())])
+        if self.chk_no_automute.isChecked(): cmd.append('--noautomute')
+        if self.chk_no_proc.isChecked(): cmd.append('--no-audio-processing')
+        if self.slider_fps.value() != 30: cmd.extend(['--fps', str(self.slider_fps.value())])
+        if self.chk_mouse.isChecked(): cmd.append('--disable-mouse')
+        if self.chk_parallax.isChecked(): cmd.append('--disable-parallax')
+        if self.chk_fs_pause.isChecked(): cmd.append('--no-fullscreen-pause')
+        scale = self.combo_scaling.currentText()
+        if scale != 'default': cmd.extend(['--scaling', scale])
+        clamp = self.combo_clamp.currentText()
+        if clamp != 'clamp': cmd.extend(['--clamp', clamp])
+        try:
+            mgr = WallpaperProcessManager()
+            mgr.start(cmd)
+            self.screen_proc_managers[screen_name] = mgr
+            self.screen_assignments[screen_name] = bg_id
+        except Exception as e:
+            logging.error("Couldn't launch wallpaper on %s: %s", screen_name, e)
 
     def detect_screens(self):
         screens = []
@@ -1258,7 +1407,10 @@ class WallpaperApp(QMainWindow):
             "no-fullscreen-pause": self.chk_fs_pause.isChecked(),
             "custom_args": self.input_custom_args.text(),
             "windowed_mode": self.chk_windowed_mode.isChecked(),
+            "keep_others": self.chk_keep_others.isChecked(),
         }
+        # Persist per-screen assignments so they can be restored on next launch.
+        self.config["screen_assignments"] = dict(self.screen_assignments)
         wallpaper_id = self.wp_id_input.text().strip()
         if wallpaper_id:
             props_out = {}


### PR DESCRIPTION
**Description:**
## Summary

Adds per-screen wallpaper management so changing the active screen in the Control tab no longer kills wallpapers running on other monitors.

## Changes

### Multi-screen support
- Added `screen_proc_managers` dict (`screen_name → WallpaperProcessManager`) to track one engine instance per screen independently
- Added `screen_assignments` dict (`screen_name → bg_id`) to persist which wallpaper is running on which screen
- New `_launch_screen(screen_name, bg_id)` helper to start a wallpaper on any screen without touching others

### "Keep wallpapers on other screens" checkbox (Control tab)
- When checked (default): "Set Wallpaper" only replaces the wallpaper on the selected screen; all other screens are untouched
- When unchecked: original behavior — kill all, start fresh on selected screen
- State persisted in config (`keep_others` key)

### "Remove Wallpaper" button (Library page)
- Always stops only the selected screen's wallpaper, leaving all other screens running
- 4-button suite re-centered using `AlignHCenter` + uniform `setSpacing` instead of hardcoded left margin

### Startup restore
- On launch, restores all per-screen assignments saved from the previous session
- Calls `kill_external_wallpapers()` before launching to clear any orphaned processes from crashes (fixes audio device multiplication on restart)

### Stop All (Control tab)
- Stop button still kills all running instances across all screens (unchanged intent, updated implementation to iterate `screen_proc_managers`)

### Checkbox indicator
- All checkboxes now render a white checkmark when checked via `checkmark.svg` injected into the Qt stylesheet

### Locale
- Added `keep_others_checkbox` and `remove_wallpaper_button` keys to all 6 locale files (en, de, fr, es, ru, uk)

## Tested on
- Hyprland (Wayland) with multiple monitors, landscape and portrait orientation
- Screen detection unchanged (xrandr)